### PR TITLE
Fix PowerShell capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -it --rm \
 
 #### Docker Desktop (Windows, Mac, Linux)
 
-(powershell example)
+(PowerShell example)
 1. Expose Docker Daemon
 2. ```shell
    docker run -it --rm -p 8080:8080 `


### PR DESCRIPTION
## Summary
- fix capitalization in README example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68418505947083248a084e1066272ee5